### PR TITLE
Popover from search no longer selects rune

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.9.0",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "backbone": "^1.4.0",
-    "bootstrap": "^4.3.1",
+    "bootstrap": "~4.0.0",
     "bootstrap-select": "^1.13.10",
     "dom-to-image": "^2.6.0",
     "jquery": "^3.4.1",
@@ -45,7 +45,7 @@
     "lz-string": "^1.4.4",
     "nprogress": "^0.2.0",
     "offline-plugin": "^5.0.7",
-    "popper.js": "^1.15.0",
+    "popper.js": "~1.12.9",
     "underscore": "^1.9.1"
   }
 }


### PR DESCRIPTION
Caused by the upgrade of bootstrap from 4.0.0 to 4.3.1
and popper.js 1.12.9 to 1.14.0

Stopped the adding of runeId to $rune.attr('data-original-title', $title.html());